### PR TITLE
fix a small bug, web app behave well now

### DIFF
--- a/network.sh
+++ b/network.sh
@@ -176,7 +176,7 @@ function generateNetworkConfig() {
       out="${out//$placeholder/,$snippet}"
     done
 
-  out="${out//$placeholder/\}\}}"
+  out="${out//$placeholder}}}"
 
   echo ${out} > $GENERATED_ARTIFACTS_FOLDER/network-config.json
 }


### PR DESCRIPTION
Before this update, web app can't run.

api.X.example.com can't start due to wrong format of  "artifacts/network-config.json" 

With the help of LeonidLe, I find the bug. It's due to a typo in network.sh



